### PR TITLE
Track people with ad-blockers

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -140,7 +140,7 @@ const config = {
     }),
     scripts: [
       {
-        src: "https://plausible.scala-lang.org/js/plausible.js",
+        src: "https://plausible.scala-lang.org/js/script.js",
         defer: true,
         async: true,
         "data-domain": "scalacenter.github.io"


### PR DESCRIPTION
It seems that some ad-blockers prevent the script `plausible.js` to be downloaded. If we use the name `script.js` it works.