### PR TITLE
📝 include information about private leaderboard

### DIFF
--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -19,7 +19,8 @@ We will strive to only use the Scala standard library to solve the puzzles, so t
 
 In addition, if you have your own solution for a puzzle and would like to share it, you can add a link to a gist in the solution page of the puzzles.
 
-If you would like to discuss the puzzles with other developers, or discuss our solutions on the following day, drop by the [the Scala Discord server](https://discord.gg/scala), in the `#advent-of-code` channel.
+If you would like to discuss the puzzles with other developers, or discuss our solutions on the following day, drop by the [the Scala Discord server](https://discord.gg/scala), in the `#advent-of-code` channel. There you can also find a pinned message with the invite code for a private leaderboard
+including those from the Scala community for some friendly competition
 
 Do you want to get your hands dirty and solve the Advent of Code puzzles in Scala?
 Read ahead to the [Setup](setup.md) page!

--- a/docs/introduction.md
+++ b/docs/introduction.md
@@ -20,7 +20,7 @@ We will strive to only use the Scala standard library to solve the puzzles, so t
 In addition, if you have your own solution for a puzzle and would like to share it, you can add a link to a gist in the solution page of the puzzles.
 
 If you would like to discuss the puzzles with other developers, or discuss our solutions on the following day, drop by the [the Scala Discord server](https://discord.gg/scala), in the `#advent-of-code` channel. There you can also find a pinned message with the invite code for a private leaderboard
-including those from the Scala community for some friendly competition
+including those from the Scala community for some friendly competition.
 
 Do you want to get your hands dirty and solve the Advent of Code puzzles in Scala?
 Read ahead to the [Setup](setup.md) page!


### PR DESCRIPTION
I posted earlier today asking if there was a private leaderboard including us nerds. I was eventually pointed to it, but it was a little more effort than it should need to be :)

This change simply notes the existence of such a private leaderboard. Paired with this, I strongly recommend a mod pin the message: https://discord.com/channels/632150470000902164/913451015246868530/1047707459990605865

I didn't want to include the leaderboard invite code directly on the page. Private leaderboards can only have 200 members, so I figure we should try to avoid bots from joining 🙃 . Those that pop into the discord are more likely to be humans.