### PR TITLE
fix regex for doc ids

### DIFF
--- a/website/src/components/DocsLinks.js
+++ b/website/src/components/DocsLinks.js
@@ -2,7 +2,7 @@ import React from 'react'
 import Link from '@docusaurus/Link';
 import useGlobalData from '@docusaurus/useGlobalData';
 
-const puzzlePage = (dir) => RegExp(`${dir}\/day(\\d+)`);
+const puzzlePage = (dir) => RegExp(`^${dir}\/day(\\d+)$`);
 
 const dayN = (rx, day) => {
   const is = rx.exec(day.id);


### PR DESCRIPTION
need to make sure that when we splice the directory name into the regex that it is the start of the string

fixes #244 