### PR TITLE
add literate coding component

### DIFF
--- a/docs/2023/puzzles/day04.md
+++ b/docs/2023/puzzles/day04.md
@@ -1,4 +1,5 @@
 import Solver from "../../../../../website/src/components/Solver.js"
+import Literate from "../../../../../website/src/components/Literate.js"
 
 # Day 4: Scratchcards
 
@@ -21,12 +22,12 @@ current card; and (2) the number of copies of cards to be processed, i.e. thei
 
 ### Count number of winning numbers
 
+<Literate>
+
 ```scala
 def countWinning(card: String): Int =
 ```
-
 Most of this function is string manipulation:
-
 ```scala
   val numbers = card
     .substring(card.indexOf(":") + 1)   // discard "Card X:"
@@ -37,7 +38,6 @@ Most of this function is string manipulation:
   // drop the initial "|"
   val givenNumbers = givenNumberStrs.drop(1).map(_.toInt).toSet
 ```
-
 Although this is not specified in the puzzle description, it seems like a number
 can appear at most once in the list of winning numbers as well as in the given
 numbers, so it is valid to perform `toSet` and the final counting step, which is
@@ -48,11 +48,14 @@ what we return:
 end countWinning
 ```
 
+</Literate>
+
 Lastly, the standard library conveniently gives us an iterator over lines.
 
 ```scala
 def winningCounts(input: String): Iterator[Int] =
   input.linesIterator.map(countWinning)
+end winningCounts
 ```
 
 ### Part 1
@@ -67,8 +70,7 @@ end part1
 
 ### Part 2
 
-(This solution is presented in literate programming style with explanations
-interspersed with lines of code.)
+<Literate>
 
 ```scala
 def part2(input: String): String =
@@ -119,6 +121,8 @@ the current card.
     ._1.toString()
 end part2
 ```
+
+</Literate>
 
 Throughout the iteration, the vector satisfies the following invariants:
 * It has at least one element.

--- a/website/src/components/Literate.js
+++ b/website/src/components/Literate.js
@@ -1,0 +1,15 @@
+import React from 'react'
+
+const Literate = ({ children }) => {
+  // see https://stackoverflow.com/a/59431317
+  const StyledChildren = () =>
+    React.Children.map(children, child =>
+      React.cloneElement(child, {
+        className: `${child.props.className} ${"literate"}`
+      })
+    );
+
+  return <StyledChildren />;
+}
+
+export default Literate

--- a/website/src/css/custom.css
+++ b/website/src/css/custom.css
@@ -30,6 +30,44 @@ html footer {
   padding: 0 var(--ifm-pre-padding);
 }
 
+.markdown> div[class*='language-']:has( + p.literate) {
+  border-bottom-right-radius: 0%;
+  border-bottom-left-radius: 0%;
+  box-shadow: none !important;
+  .codeBlockLines_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
+    padding-bottom: 5px !important;
+  }
+}
+
+.markdown > p.literate {
+  z-index: 100;
+  background-color: rgb(231, 233, 239);
+  /* box-shadow: rgba(0, 0, 0, 0.1) 0px 1px 2px 0px; */
+  margin-top: calc(-4px + -1 * var(--ifm-pre-padding)) !important;
+  margin: 0;
+  padding: var(--ifm-pre-padding);
+  display: block;
+  border-left: #b75051 5px solid;
+  border-bottom: rgb(215, 222, 227) 1px solid;
+  border-top: rgb(215, 222, 227) 1px solid;
+}
+
+.markdown>p.literate + div[class*='language-'] {
+  border-top-right-radius: 0%;
+  border-top-left-radius: 0%;
+  box-shadow: none !important;
+  .codeBlockLines_node_modules-\@docusaurus-theme-classic-lib-theme-CodeBlock-Content-styles-module {
+    padding-top: 5px !important;
+  }
+}
+
+html[data-theme='dark'] p.literate {
+  background-color: rgb(52, 57, 71);
+  border-left: #992527 5px solid;
+  border-bottom: rgb(59, 65, 80) 1px solid;
+  border-top: rgb(59, 65, 80) 1px solid;
+}
+
 html[data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }


### PR DESCRIPTION
Update day 4 article to use a new `<Literate>` react component that will group code blocks and paragraphs as follows:

<img width="764" alt="Screenshot 2023-12-05 at 11 57 04" src="https://github.com/scalacenter/scala-advent-of-code/assets/13436592/fd006ca4-e080-48ef-9ecc-f9157c9ef4bb">
<img width="764" alt="Screenshot 2023-12-05 at 11 57 14" src="https://github.com/scalacenter/scala-advent-of-code/assets/13436592/f241933f-2a01-4417-a7da-e64f825b632f">

~~~mdx

### String Manipulation

Here is code
<Literate>

```scala
def foo(a: String): Int =
```
we're going to do fancy stuff with this `String`.
```scala
  val length = s.size
  val hash = s.hashCode
```
Now something even more wild!

```scala
  length + hash
end foo
```

</Literate>

~~~