### PR TITLE
chore: add all `.bloop` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Scala stuff
-/.bloop/
+.bloop/
 .bsp/
 metals.sbt
 target/


### PR DESCRIPTION
hides `project/.bloop` which somehow gets generated when importing project in metals