### PR TITLE
Change my article's author to my display name

### DIFF
--- a/docs/2024/puzzles/day12.md
+++ b/docs/2024/puzzles/day12.md
@@ -1,7 +1,7 @@
 import Solver from "../../../../../website/src/components/Solver.js"
 
 # Day 12: Garden Groups
-by [@TheDrawingCoder-Gamer](https://github.com/TheDrawingCoder-Gamer)
+by [Bulby](https://github.com/TheDrawingCoder-Gamer)
 
 
 ## Puzzle description

--- a/docs/2024/puzzles/day18.md
+++ b/docs/2024/puzzles/day18.md
@@ -1,7 +1,7 @@
 import Solver from "../../../../../website/src/components/Solver.js"
 
 # Day 18: RAM Run
-by [@TheDrawingCoder-Gamer](https://github.com/TheDrawingCoder-Gamer)
+by [Bulby](https://github.com/TheDrawingCoder-Gamer)
 
 ## Puzzle description
 


### PR DESCRIPTION
I hate my username, replace `@TheDrawingCoder-Gamer` with `Bulby` in the "by ..." sections of my articles.